### PR TITLE
Add ability to use an exclusion file with the "-x" argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@
 $ src/rback -h
 
 Usage: rback -h
-       rback -- UNIT START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
-       rback -r -- UNIT1 START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
+       rback [--exclude-file <filename>] -- UNIT START INTERVAL LIMIT SRC1 \
+           [ SRC2 [ ... ] ] DEST
+       rback -r [--exclude-file <filename>] -- UNIT1 START1 INTERVAL1 LIMIT1 \
+           UNIT2 START2 INTERVAL2 DEST
   OPTIONS
     -h, --help          Display this help message
     -r, --rotate        Rotate snapshots.  Update snapshots without backing up
+    -x, --exclude-file  Flag for exclusion file passed to Rsync
   ARGS
     UNIT                Unit of time (minute, hour, day, week, month, etc.)
     START               Integer elapsed start time, time for first snapshot

--- a/features/exclusion_file.feature
+++ b/features/exclusion_file.feature
@@ -32,3 +32,9 @@ Scenario: The user backs up a file in a directory but excludes a non-empty subdi
     And executes "rback -x ${TEMP_TEST_DIR}/excludes -- hour 4 4 12 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}/"
     Then a copy of "${TEMP_TEST_DIR}/my_file.txt" is made at "${TEMP_TEST_DIR}/hour.4.4/subdir/my_file.txt"
     But "${TEMP_TEST_DIR}/files/subdir/do_not_copy" is not copied into the "${TEMP_TEST_DIR}/hour.4.4/" directory
+
+Scenario: The user looks up the command line option for including an exclusion file
+    When the user types "rback -h"
+    Then "[--exclude-file <filename>]" is shown in the usage information for "rback"
+    And "[--exclude-file <filename>]" is shown in the usage information for "rback -r"
+    And the options "-x, --exclude-file" appear as well

--- a/src/rback
+++ b/src/rback
@@ -16,11 +16,14 @@ assert_positive_int_arg() {
 usage() {
   local usage_string
   usage_string="Usage: rback -h
-       rback -- UNIT START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
-       rback -r -- UNIT1 START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
+       rback [--exclude-file <filename>] -- UNIT START INTERVAL LIMIT SRC1 \\
+           [ SRC2 [ ... ] ] DEST
+       rback -r [--exclude-file <filename>] -- UNIT1 START1 INTERVAL1 LIMIT1 \\
+           UNIT2 START2 INTERVAL2 DEST
   OPTIONS
     -h, --help          Display this help message
     -r, --rotate        Rotate snapshots.  Update snapshots without backing up
+    -x, --exclude-file  Flag for exclusion file passed to Rsync
   ARGS
     UNIT                Unit of time (minute, hour, day, week, month, etc.)
     START               Integer elapsed start time, time for first snapshot

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -277,3 +277,10 @@ assert_inodes_not_equal() {
   diff "${TEMP_TEST_DIR}/files/subdir/my_file.txt" "${TEMP_TEST_DIR}/hour.4.4/subdir/my_file.txt"
   assert_dir_not_exists "${TEMP_TEST_DIR}/hour.4.4/subdir/do_not_copy"
 }
+
+@test "the user looks up the command line option for an exclusion file" {
+  run rback -h
+  assert_output --partial "rback [--exclude-file <filename>]"
+  assert_output --partial "rback -r [--exclude-file <filename>]"
+  assert_output --partial "-x, --exclude-file"
+}


### PR DESCRIPTION
This is a new feature that can be viewed as a wrapper for the Rsync "--exclude-from=FILE" command line option.

`tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
`tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
`shellcheck src/rback` passed with ShellCheck version 0.7.0