### PR TITLE
Add ability to enable logging with "-v" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 $ src/rback -h
 
 Usage: rback -h
-       rback [ [ --delete-excluded ] --exclude-file <filename> ] -- UNIT \
-           START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
-       rback -r [ [ --delete-excluded ] --exclude-file <filename> ] -- UNIT1 \
-           START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
+       rback [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \
+           -- UNIT START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
+       rback -r [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \
+           -- UNIT1 START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
   OPTIONS
     -h, --help            Display this help message
     -r, --rotate          Rotate snapshots.  Update snapshots without back up
+    -v, --verbose         Enable logging.  Verbose output with timestamps
     -x, --exclude-file    Flag for exclusion file passed to Rsync
     -d, --delete-excluded Flag for deleting excluded backup files and folders
   ARGS

--- a/features/logging.feature
+++ b/features/logging.feature
@@ -46,3 +46,9 @@ Scenario: The user passes an unknown option with logging enabled
     And a message is printed to standard error
     And the message contains the phrase 'Unknown option "-z"'
     And the message contains the current time stamp within a 5 second difference
+
+Scenario: The user looks up the command line option for logging
+    When the user enters "rback -h"
+    Then "[ -v ]" is shown in the usage information for "rback"
+    And "[ -v ]" is shown in the usage information for "rback -r"
+    And the options "-v, --verbose" appear as well

--- a/src/rback
+++ b/src/rback
@@ -21,13 +21,14 @@ assert_positive_int_arg() {
 usage() {
   local usage_string
   usage_string="Usage: rback -h
-       rback [ [ --delete-excluded ] --exclude-file <filename> ] -- UNIT \\
-           START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
-       rback -r [ [ --delete-excluded ] --exclude-file <filename> ] -- UNIT1 \\
-           START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
+       rback [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \\
+           -- UNIT START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
+       rback -r [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \\
+           -- UNIT1 START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
   OPTIONS
     -h, --help            Display this help message
     -r, --rotate          Rotate snapshots.  Update snapshots without back up
+    -v, --verbose         Enable logging.  Verbose output with timestamps
     -x, --exclude-file    Flag for exclusion file passed to Rsync
     -d, --delete-excluded Flag for deleting excluded backup files and folders
   ARGS

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -360,8 +360,8 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
 
 @test "the user looks up usage info for deleting excluded files and folders" {
   run rback -h
-  assert_output --partial "rback [ [ --delete-excluded ] "
-  assert_output --regexp "rback -r [ [ --delete-excluded ] "
+  assert_output --regexp "rback .*[ [ --delete-excluded ] "
+  assert_output --regexp "rback -r .*[ [ --delete-excluded ] "
   assert_output --partial "-d, --delete-excluded"
 }
 
@@ -413,4 +413,12 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_failure
   assert_output --partial "Unknown option \"-z\""
   assert_current_timestamp
+}
+
+@test "the user looks up the command line option for logging" {
+  run rback -h
+
+  assert_output --partial "rback [ -v ] "
+  assert_output --partial "rback -r [ -v ] "
+  assert_output --partial "-x, --exclude-file"
 }


### PR DESCRIPTION
This is a new feature that produces verbose output with timestamps when the "-v" command line option is used.

`tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
`tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
`shellcheck src/rback` passed with ShellCheck version 0.7.0