### PR TITLE
Use lower case for test descriptions

### DIFF
--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -304,7 +304,7 @@ assert_current_timestamp() {
   assert_file_exists "${TEMP_TEST_DIR}/hour.4.4/exclude_me.txt"
 }
 
-@test "The user backs up a file and deletes an excluded file in backup" {
+@test "the user backs up a file and deletes an excluded file in backup" {
   mkdir "${TEMP_TEST_DIR}/files"
   touch "${TEMP_TEST_DIR}/files/my_file.txt"
   echo "- exclude_me.txt" > "${TEMP_TEST_DIR}/excludes"
@@ -319,7 +319,7 @@ assert_current_timestamp() {
   assert_file_not_exists "${TEMP_TEST_DIR}/hour.4.4/exclude_me.txt"
 }
 
-@test "The user backs up a file without deleting a non-empty backup directory" {
+@test "the user backs up a file without deleting a non-empty backup directory" {
   mkdir "${TEMP_TEST_DIR}/files"
   touch "${TEMP_TEST_DIR}/files/my_file.txt"
   echo "- do_not_delete" > "${TEMP_TEST_DIR}/excludes"
@@ -335,7 +335,7 @@ assert_current_timestamp() {
   assert_file_exists "${TEMP_TEST_DIR}/hour.4.4/do_not_delete/hello.txt"
 }
 
-@test "The user backs up a file and deletes a non-empty backup directory" {
+@test "the user backs up a file and deletes a non-empty backup directory" {
   mkdir "${TEMP_TEST_DIR}/files"
   touch "${TEMP_TEST_DIR}/files/my_file.txt"
   echo "- delete_me" > "${TEMP_TEST_DIR}/excludes"
@@ -350,7 +350,7 @@ assert_current_timestamp() {
   assert_dir_not_exists "${TEMP_TEST_DIR}/hour.4.4/delete_me"
 }
 
-@test "The user forgets the \"-x\" option when using \"--delete-excluded\"" {
+@test "the user forgets the \"-x\" option when using \"--delete-excluded\"" {
   mkdir "${TEMP_TEST_DIR}/files"
   touch "${TEMP_TEST_DIR}/files/my_file.txt"
 run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TEST_DIR}"


### PR DESCRIPTION
Fixes #5.  This is a minor bug fix to keep the first letter of each word in each test description consistently lower case.

- `tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
- `tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
- `shellcheck src/rback` passed with ShellCheck version 0.7.0
  