### PR TITLE
Add timestamps for all error messages with "-v"

### DIFF
--- a/features/error_timestamp.feature
+++ b/features/error_timestamp.feature
@@ -28,3 +28,12 @@ Scenario: The user passes "-d" and "-v" without "-x"
     And a message is printed to standard error
     And the message contains '"-x" is required with "-d"'
     And the message contains the current timestamp within a 5 second difference
+
+Scenario: The user passes "-v" with an existing directory conflict
+    Given the directory "${TEMP_TEST_DIR}/hour.6.2" exists
+    And the directory "${TEMP_TEST_DIR}/minute.120.30" exists
+    When the user executes "rback -r -v -- hour 2 2 4 minute 120 30 ${TEMP_TEST_DIR}"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains "${TEMP_TEST_DIR}/hour.6.2 already exists"
+    And the message contains the current timestamp within a 5 second difference

--- a/features/error_timestamp.feature
+++ b/features/error_timestamp.feature
@@ -1,0 +1,15 @@
+Feature: print timestamps for all error messages with "-v"
+
+Background:
+    Given the user has an open terminal with a command line prompt
+    And "${TEMP_TEST_DIR}" is a valid path to a directory
+    And the rback script is on the path
+    And Rsync is intalled
+
+
+Scenario: The user passes fewer than 6 arguments with "-v"
+    When the user executes "run rback -v -- minute 30 30 480 "${TEMP_TEST_DIR}"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains the phrase "at least 6 required"
+    And the message contains the current timestamp within a 5 second difference

--- a/features/error_timestamp.feature
+++ b/features/error_timestamp.feature
@@ -4,7 +4,7 @@ Background:
     Given the user has an open terminal with a command line prompt
     And "${TEMP_TEST_DIR}" is a valid path to a directory
     And the rback script is on the path
-    And Rsync is intalled
+    And Rsync is installed
 
 
 Scenario: The user passes fewer than 6 arguments with "-v"
@@ -12,4 +12,11 @@ Scenario: The user passes fewer than 6 arguments with "-v"
     Then the command fails
     And a message is printed to standard error
     And the message contains the phrase "at least 6 required"
+    And the message contains the current timestamp within a 5 second difference
+
+Scenario: The user passes the wrong number of arguments with "-r" and "-v"
+    When the user executes "run rback -r -v -- minute 10 120 10 hour 2 2"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains the phrase "expected 8"
     And the message contains the current timestamp within a 5 second difference

--- a/features/error_timestamp.feature
+++ b/features/error_timestamp.feature
@@ -20,3 +20,11 @@ Scenario: The user passes the wrong number of arguments with "-r" and "-v"
     And a message is printed to standard error
     And the message contains the phrase "expected 8"
     And the message contains the current timestamp within a 5 second difference
+
+Scenario: The user passes "-d" and "-v" without "-x"
+    Given the directory "${TEMP_TEST_DIR}/files" exists
+    When the user executes "rback -v -d -- hour 4 4 12 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains '"-x" is required with "-d"'
+    And the message contains the current timestamp within a 5 second difference

--- a/src/rback
+++ b/src/rback
@@ -19,6 +19,9 @@ assert_positive_int_arg() {
 }
 
 usage() {
+  if [[ "$1" == "true" ]]; then
+      echo "$(date +"%F %T"): INFO:"
+  fi
   local usage_string
   usage_string="Usage: rback -h
        rback [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \\
@@ -158,6 +161,8 @@ main() {
   verbose="false"
   local unknown_option
   unknown_option=""
+  local error_prefix
+  error_prefix=""
 
   while :; do
     case "$1" in
@@ -184,8 +189,9 @@ main() {
   fi
 
   if (( $# < 6  )); then
-    usage
-    error "${FUNCNAME[0]}: ${LINENO[0]}: $# arguments, but at least 6 required"
+    usage "${verbose}"
+    error_prefix="${FUNCNAME[0]}: ${LINENO[0]}:"
+    error "${error_prefix}: $# arguments, but at least 6 required" "${verbose}"
   fi
   if [[ "${rotate_flag}" == "true" ]] && (( $# != 8 )); then
     usage
@@ -215,7 +221,6 @@ main() {
   shift
 
   if (( start > limit )); then
-    local error_prefix
     error_prefix="${FUNCNAME[0]}: ${LINENO[0]}:"
     error "${error_prefix} START ${start} exceeds LIMIT ${limit}" "${verbose}"
   fi

--- a/src/rback
+++ b/src/rback
@@ -56,13 +56,14 @@ usage() {
 # an empty snapshot folder corresponding to <start> <time unit>s will be
 # created.
 #
-# Usage: rotate <backup dir> <time unit> <start> <interval> <limit>
+# Usage: rotate <backup dir> <time unit> <start> <interval> <limit> [<verbose>]
 #
 # Inputs: <backup dir> - path to the directory containing all snapshot folders
 #         <time unit> - unit of time ("minute","hour","day",etc.)
 #         <start> - integer elapsed start time, time of the first snapshot
 #         <interval> - integer interval of elapsed time, time between snapshots
 #         <limit> - integer limit of elapsed time, time limit of snapshots
+#         <verbose> - (optional) if "true", then print verbose output
 #
 # In the backup directory, a snapshot folder for <limit> + <interval> elapsed
 # time will be created temporarily if it does not already exist; otherwise,
@@ -79,13 +80,16 @@ rotate() {
   interval=$4
   local limit
   limit=$5
+  local verbose
+  verbose=$6
 
   local temp_folder # temporary snapshot folder name
   temp_folder="${backup_dir}/${time_unit}.$(( limit + interval ))"
   temp_folder+=".$(( interval ))"
 
   if [[ -d "${temp_folder}" ]]; then
-    error "${FUNCNAME[0]}: ${LINENO[0]}: ${temp_folder} already exists"
+    error "${FUNCNAME[0]}: ${LINENO[0]}: ${temp_folder} already exists" \
+        "${verbose}"
   fi
 
   for (( n = limit; n >= start; n -= interval )); do
@@ -250,7 +254,8 @@ main() {
     link_dest="${source_dir[0]}"
   fi
   
-  rotate "${backup_dir}" "${time_unit}" "${start}" "${interval}" "${limit}"
+  rotate "${backup_dir}" "${time_unit}" "${start}" "${interval}" "${limit}" \
+      "${verbose}"
   target_dir="${backup_dir}/${time_unit}.$(( start )).${interval}"
 
   local rsync_opts

--- a/src/rback
+++ b/src/rback
@@ -185,7 +185,8 @@ main() {
 
 
   if [[ "${delete_excluded}" == "true" ]] && ! [[ -f "${exclude_file}" ]]; then
-      error "${FUNCNAME[0]}: ${LINENO[0]}: \"-x\" is required with \"-d\""
+    error "${FUNCNAME[0]}: ${LINENO[0]}: \"-x\" is required with \"-d\"" \
+        "${verbose}"
   fi
 
   if (( $# < 6  )); then

--- a/src/rback
+++ b/src/rback
@@ -194,8 +194,9 @@ main() {
     error "${error_prefix}: $# arguments, but at least 6 required" "${verbose}"
   fi
   if [[ "${rotate_flag}" == "true" ]] && (( $# != 8 )); then
-    usage
-    error "${FUNCNAME[0]}: ${LINENO[0]}: $# arguments, but expected 8"
+    usage "${verbose}"
+    error "${FUNCNAME[0]}: ${LINENO[0]}: $# arguments, but expected 8" \
+        "${verbose}"
   fi
 
   local time_unit

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -445,3 +445,12 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_output --partial "expected 8"
   assert_current_timestamp
 }
+
+@test "the user passes \"-d\" and \"-v\" without \"-x\"" {
+  mkdir "${TEMP_TEST_DIR}/files"
+  run rback --delete-excluded -v -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" \
+      "${TEMP_TEST_DIR}"
+  assert_failure
+  assert_output --partial "\"-x\" is required with \"-d\""
+  assert_current_timestamp
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -431,3 +431,10 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_failure
   assert_output --partial "START 2 exceeds LIMIT 1"
 }
+
+@test "the user passes fewer than 6 arguments with \"-v\"" {
+  run rback -v -- minute 30 30 480 "${TEMP_TEST_DIR}"
+  assert_failure
+  assert_output --partial "at least 6 required"
+  assert_current_timestamp
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -434,6 +434,7 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
 
 @test "the user passes fewer than 6 arguments with \"-v\"" {
   run rback -v -- minute 30 30 480 "${TEMP_TEST_DIR}"
+
   assert_failure
   assert_output --partial "at least 6 required"
   assert_current_timestamp
@@ -441,6 +442,7 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
 
 @test "the user passes the wrong number of arguments with \"-r\" and \"-v\"" {
   run rback -r -v -- minute 10 120 10 hour 2 2
+
   assert_failure
   assert_output --partial "expected 8"
   assert_current_timestamp
@@ -448,9 +450,22 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
 
 @test "the user passes \"-d\" and \"-v\" without \"-x\"" {
   mkdir "${TEMP_TEST_DIR}/files"
+
   run rback --delete-excluded -v -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" \
       "${TEMP_TEST_DIR}"
+
   assert_failure
   assert_output --partial "\"-x\" is required with \"-d\""
+  assert_current_timestamp
+}
+
+@test "the user passes \"-v\" with existing directory conflict" {
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.6.2"
+  mkdir "${TEMP_TEST_DIR}/minute.120.30"
+
+  run rback -r -v -- hour 2 2 4 minute 120 30 "${TEMP_TEST_DIR}"
+
+  assert_failure
+  assert_output --partial "${TEMP_TEST_DIR}/hour.6.2 already exists"
   assert_current_timestamp
 }

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -438,3 +438,10 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_output --partial "at least 6 required"
   assert_current_timestamp
 }
+
+@test "the user passes the wrong number of arguments with \"-r\" and \"-v\"" {
+  run rback -r -v -- minute 10 120 10 hour 2 2
+  assert_failure
+  assert_output --partial "expected 8"
+  assert_current_timestamp
+}


### PR DESCRIPTION
This closes #7.  This is a new feature that ensures all error messages include timestamps when the "--verbose" flag is used.

- `tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
- `tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
- `shellcheck src/rback` passed with ShellCheck version 0.7.0