### PR TITLE
Add ability to temporarily append anything to the end of snapshot folder names

### DIFF
--- a/features/append_anything.feature
+++ b/features/append_anything.feature
@@ -48,3 +48,14 @@ Scenario: The user appends "hello" to a snapshot and rotates snapshots
     And the directory "${TEMP_TEST_DIR}/hour.2.2" exists
     And the directory "${TEMP_TEST_DIR}/hour.6.2_hello" does not exist
     And the directory "${TEMP_TEST_DIR}/hour.2.2_hello" does not exist
+
+Scenario: The user appends "hello" to a snapshot and backs up
+    Given the directory "${TEMP_TEST_DIR}/hour.6.2 exists
+    And the directory "${TEMP_TEST_DIR}/files" exists
+    When the user renames the directory "${TEMP_TEST_DIR}/hour.6.2" to "${TEMP_TEST_DIR}/hour.6.2_hello"
+    And executes "rback -- hour 2 2 6 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}"
+    Then the command succeeds
+    And the directory "${TEMP_TEST_DIR}/hour.6.2" exists
+    And the directory "${TEMP_TEST_DIR}/hour.2.2" exists
+    And the directory "${TEMP_TEST_DIR}/hour.6.2_hello" does not exist
+    And the directory "${TEMP_TEST_DIR}/hour.2.2_hello" does not exist

--- a/features/append_anything.feature
+++ b/features/append_anything.feature
@@ -37,3 +37,14 @@ Scenario: The user backs up after appending "hello" to limit+interval snapshot
     Then the command fails
     And a message is printed to standard error
     And the message contains the phrase "${TEMP_TEST_DIR}/hour.8.2_hello already exists"
+
+Scenario: The user appends "hello" to a snapshot and rotates snapshots
+    Given the directory "${TEMP_TEST_DIR}/hour.6.2 exists
+    And the directory "${TEMP_TEST_DIR}/minute.120.30" exists
+    When the user renames the directory "${TEMP_TEST_DIR}/hour.6.2" to "${TEMP_TEST_DIR}/hour.6.2_hello"
+    And executes "rback -r -- hour 2 2 6 minute 120 30 ${TEMP_TEST_DIR}"
+    Then the command succeeds
+    And the directory "${TEMP_TEST_DIR}/hour.6.2" exists
+    And the directory "${TEMP_TEST_DIR}/hour.2.2" exists
+    And the directory "${TEMP_TEST_DIR}/hour.6.2_hello" does not exist
+    And the directory "${TEMP_TEST_DIR}/hour.2.2_hello" does not exist

--- a/features/append_anything.feature
+++ b/features/append_anything.feature
@@ -29,3 +29,11 @@ Scenario: The user copies a snapshot, appends "hello", and backs up
     And the message contains the phrase "conflicting snapshot names"
     And the message contains "${TEMP_TEST_DIR}/hour.2.2"
     And the message contains "${TEMP_TEST_DIR}/hour.2.2_hello"
+
+Scenario: The user backs up after appending "hello" to limit+interval snapshot
+    Given the directory "${TEMP_TEST_DIR}/files" exists
+    When the user creates the directory "${TEMP_TEST_DIR}/hour.8.2_hello"
+    And the user executes "rback -- hour 2 2 6 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains the phrase "${TEMP_TEST_DIR}/hour.8.2_hello already exists"

--- a/features/append_anything.feature
+++ b/features/append_anything.feature
@@ -17,3 +17,15 @@ Scenario: The user copies a snapshot, appends "hello", and rotates snapshots
     And the message contains the phrase "conflicting snapshot names"
     And the message contains "${TEMP_TEST_DIR}/minute.120.30"
     And the message contains "${TEMP_TEST_DIR}/minute.120.30_hello"
+
+Scenario: The user copies a snapshot, appends "hello", and backs up
+    Given the directory "${TEMP_TEST_DIR}/hour.2.2" exists
+    And the directory "${TEMP_TEST_DIR}/files" exists
+    When the user copies the directory "${TEMP_TEST_DIR}/hour.2.2"
+    And the user renames the copy "${TEMP_TEST_DIR}hour.2.2_hello"
+    And the user executes "rback -- hour 2 2 6 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains the phrase "conflicting snapshot names"
+    And the message contains "${TEMP_TEST_DIR}/hour.2.2"
+    And the message contains "${TEMP_TEST_DIR}/hour.2.2_hello"

--- a/features/append_anything.feature
+++ b/features/append_anything.feature
@@ -1,0 +1,19 @@
+Feature: Anything can be temporarily appended to snapshot folder names
+
+Background:
+    Given the user has an open terminal with a command line prompt
+    And "${TEMP_TEST_DIR}" is a valid path to a directory
+    And the rback script is on the path
+    And Rsync is installed
+
+
+Scenario: The user copies a snapshot, appends "hello", and rotates snapshots
+    Given the directory "${TEMP_TEST_DIR}/minute.120.30" exists
+    When the user copies the directory "${TEMP_TEST_DIR}/minute.120.30"
+    And the user names the copy "${TEMP_TEST_DIR}/minute.120.30_hello"
+    And the user executes "rback -r -- hour 2 2 4 minute 120 30 "${TEMP_TEST_DIR}"
+    Then the command fails
+    And a message is printed to standard error
+    And the message contains the phrase "conflicting snapshot names"
+    And the message contains "${TEMP_TEST_DIR}/minute.120.30"
+    And the message contains "${TEMP_TEST_DIR}/minute.120.30_hello"

--- a/src/rback
+++ b/src/rback
@@ -131,21 +131,17 @@ update() {
   local interval
   interval=$4
   local snapshot_to_update
-  # TO DO: call snapshot_dir_name:
-  snapshot_to_update=${snapshot_prefix}$(( elapsed_time )).$(( interval ))
+  snapshot_to_update="$(snapshot_dir_name "$1" "$2" "$3" "$4")"
 
   if (( $# == 4 )); then
     if [[ -d "${snapshot_to_update}" ]]; then
-      # TO DO: call snapshot_dir_name:
       mv -- "${snapshot_to_update}" \
           "${snapshot_prefix}$(( elapsed_time + interval )).$(( interval ))"
     fi
   elif (( $# == 5 )); then
     if [[ -d "${snapshot_to_update}" ]]; then
-      # TO DO: call snapshot_dir_name:
       mv -- "${snapshot_to_update}" "${snapshot_prefix}$5.$(( interval ))"
     else
-      # TO DO: call snapshot_dir_name:
       mkdir "${snapshot_prefix}$5.$(( interval ))"
     fi
   else

--- a/src/rback
+++ b/src/rback
@@ -2,6 +2,8 @@
 #
 # Rsync-based script for backups
 
+set -e
+
 error() {
   local timestamp
   timestamp=""
@@ -84,6 +86,7 @@ rotate() {
   verbose=$6
 
   local temp_folder # temporary snapshot folder name
+  # TO DO: call snapshot_dir_name:
   temp_folder="${backup_dir}/${time_unit}.$(( limit + interval ))"
   temp_folder+=".$(( interval ))"
 
@@ -129,23 +132,76 @@ update() {
   local interval
   interval=$4
   local snapshot_to_update
+  # TO DO: call snapshot_dir_name:
   snapshot_to_update=${snapshot_prefix}$(( elapsed_time )).$(( interval ))
 
   if (( $# == 4 )); then
     if [[ -d "${snapshot_to_update}" ]]; then
+      # TO DO: call snapshot_dir_name:
       mv -- "${snapshot_to_update}" \
           "${snapshot_prefix}$(( elapsed_time + interval )).$(( interval ))"
     fi
   elif (( $# == 5 )); then
     if [[ -d "${snapshot_to_update}" ]]; then
+      # TO DO: call snapshot_dir_name:
       mv -- "${snapshot_to_update}" "${snapshot_prefix}$5.$(( interval ))"
     else
+      # TO DO: call snapshot_dir_name:
       mkdir "${snapshot_prefix}$5.$(( interval ))"
     fi
   else
     local error_prefix
     error_prefix="${FUNCNAME[0]}: ${LINENO[0]}:"
     error "${error_prefix} $# arguments were passed, but expected 4 or 5."
+  fi
+}
+
+# Print the unique snapshot directory name based on the input arguments
+#
+# Usage: snapshot_dir_name <backup dir> <time unit> <elapsed time> <interval> \
+#           [ <verbose> ]
+#
+# Inputs:
+#    <backup dir> - path to the directory containing all the snapshot folders
+#    <time unit> - unit of time ("minute","hour","day",etc.)
+#    <elapsed time> - integer elapsed time for the snapshot
+#    <interval> - integer interval of elapsed time
+#    <verbose> - (optional) if "true", then print verbose output for errors
+#
+# This function prints the unique name of the snapshot folder made after
+# <elapsed time> <time unit>s of time with the snapshot made every <interval>
+# <time unit>s if the snapshot folder already exists.  The format of the
+# snapshot folder name is "<unit>.<elapsed time>.<interval>" with any appended
+# information ignored.  If there is more than one folder name corresponding to
+# the snapshot, then an error will occur.  If no snapshot folder exists, then
+# the name with nothing appended will be returned.
+snapshot_dir_name() {
+  local backup_dir
+  backup_dir=$1
+  local dir_prefix
+  dir_prefix="$2.$3.$4"
+  local verbose
+  verbose=$5
+
+  local entries
+  readarray -t entries < <(ls -N -1 -- "${backup_dir}")
+  local snapshot_names
+  snapshot_names=()
+  for entry in "${entries[@]}"; do
+    if [[ "${entry}" =~ ^${dir_prefix}.* ]] \
+        && [[ -d "${backup_dir}/${entry}" ]]; then
+      snapshot_names+=("${backup_dir}/${entry}")
+    fi
+  done
+
+  if (( ${#snapshot_names[@]} == 0 )); then
+    echo "${backup_dir}/${dir_prefix}"
+  elif (( ${#snapshot_names[@]} == 1 )); then
+    echo "${snapshot_names[0]}"
+  else
+    local error_prefix="${FUNCNAME[0]}: ${LINENO[0]}: "
+    error "${error_prefix}conflicting snapshot names: ${snapshot_names[*]}" \
+        "${verbose}"
   fi
 }
 
@@ -243,6 +299,7 @@ main() {
       shift
     done
     backup_dir="$1"
+    # TO DO: call snapshot_dir_name:
     link_dest="${backup_dir}/${time_unit}.$(( start + interval )).${interval}"
   else
     backup_dir="$4"
@@ -250,12 +307,16 @@ main() {
         "${verbose}"
     assert_positive_int_arg "$3" "${FUNCNAME[0]}" "${LINENO[0]}" "seventh" \
         "${verbose}"
-    source_dir=("${backup_dir}/$1.$2.$3/")
+    # for error propagation, do not substitute expression for snap_dir
+    local snap_dir
+    snap_dir="$(snapshot_dir_name "${backup_dir}" "$1" "$2" "$3" "${verbose}")"
+    source_dir=("${snap_dir}/")
     link_dest="${source_dir[0]}"
   fi
   
   rotate "${backup_dir}" "${time_unit}" "${start}" "${interval}" "${limit}" \
       "${verbose}"
+  # TO DO: call snapshot_dir_name:
   target_dir="${backup_dir}/${time_unit}.$(( start )).${interval}"
 
   local rsync_opts

--- a/src/rback
+++ b/src/rback
@@ -182,14 +182,12 @@ snapshot_dir_name() {
   local verbose
   verbose=$5
 
-  local entries
-  readarray -t entries < <(ls -N -1 -- "${backup_dir}")
   local snapshot_names
   snapshot_names=()
-  for entry in "${entries[@]}"; do
-    if [[ "${entry}" =~ ^${dir_prefix}.* ]] \
-        && [[ -d "${backup_dir}/${entry}" ]]; then
-      snapshot_names+=("${backup_dir}/${entry}")
+  for entry in "${backup_dir}"/*; do
+    if [[ "${entry}" =~ ^${backup_dir}/${dir_prefix}.* ]] \
+        && [[ -d "${entry}" ]]; then
+      snapshot_names+=("${entry}")
     fi
   done
 

--- a/src/rback
+++ b/src/rback
@@ -86,9 +86,8 @@ rotate() {
   verbose=$6
 
   local temp_folder # temporary snapshot folder name
-  # TO DO: call snapshot_dir_name:
-  temp_folder="${backup_dir}/${time_unit}.$(( limit + interval ))"
-  temp_folder+=".$(( interval ))"
+  temp_folder="$(snapshot_dir_name "${backup_dir}" "${time_unit}" \
+      "$(( limit + interval ))" "${interval}" "${verbose}")"
 
   if [[ -d "${temp_folder}" ]]; then
     error "${FUNCNAME[0]}: ${LINENO[0]}: ${temp_folder} already exists" \

--- a/src/rback
+++ b/src/rback
@@ -299,8 +299,8 @@ main() {
       shift
     done
     backup_dir="$1"
-    # TO DO: call snapshot_dir_name:
-    link_dest="${backup_dir}/${time_unit}.$(( start + interval )).${interval}"
+    link_dest="$(snapshot_dir_name "${backup_dir}" "${time_unit}" \
+        "$(( start + interval ))" "${interval}" "${verbose}")"
   else
     backup_dir="$4"
     assert_positive_int_arg "$2" "${FUNCNAME[0]}" "${LINENO[0]}" "sixth" \
@@ -313,11 +313,11 @@ main() {
     source_dir=("${snap_dir}/")
     link_dest="${source_dir[0]}"
   fi
-  
+
   rotate "${backup_dir}" "${time_unit}" "${start}" "${interval}" "${limit}" \
       "${verbose}"
-  # TO DO: call snapshot_dir_name:
-  target_dir="${backup_dir}/${time_unit}.$(( start )).${interval}"
+  target_dir="$(snapshot_dir_name "${backup_dir}" "${time_unit}" \
+      "$(( start ))" "${interval}" "${verbose}")"
 
   local rsync_opts
   rsync_opts=("--link-dest=${link_dest}" --delete -a)

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -472,12 +472,25 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
 
 @test "the user copies a snapshot, appends \"hello\", and rotates snapshots" {
   mkdir "${TEMP_TEST_DIR}/minute.120.30"
+  
   cp -r "${TEMP_TEST_DIR}/minute.120.30" "${TEMP_TEST_DIR}/minute.120.30_hello"
-
   run rback --rotate -- hour 2 2 6 minute 120 30 "${TEMP_TEST_DIR}"
 
   assert_failure
   assert_output --partial "conflicting snapshot names"
   assert_output --partial "${TEMP_TEST_DIR}/minute.120.30"
   assert_output --partial "${TEMP_TEST_DIR}/minute.120.30_hello"
+}
+
+@test "the user copies a snapshot, appends \"hello\", and backs up" {
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.2.2"
+  mkdir "${TEMP_TEST_DIR}/files"
+
+  cp -r "${TEMP_TEST_DIR}/hour.2.2" "${TEMP_TEST_DIR}/hour.2.2_hello"
+  run rback -- hour 2 2 6 "${TEMP_TEST_DIR}/files/" "${TEMP_TEST_DIR}"
+
+  assert_failure
+  assert_output --partial "conflicting snapshot names"
+  assert_output --partial "${TEMP_TEST_DIR}/hour.2.2"
+  assert_output --partial "${TEMP_TEST_DIR}/hour.2.2_hello"
 }

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -504,3 +504,17 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_failure
   assert_output --partial "${TEMP_TEST_DIR}/hour.8.2_hello already exists"
 }
+
+@test "the user appends \"hello\" to a snapshot and rotates snapshots" {
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.6.2"
+  mkdir "${TEMP_TEST_DIR}/minute.120.30"
+
+  mv -- "${TEMP_TEST_DIR}/hour.6.2" "${TEMP_TEST_DIR}/hour.6.2_hello"
+  run rback -r -- hour 2 2 6 minute 120 30 "${TEMP_TEST_DIR}"
+
+  assert_success
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.6.2"
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.2.2"
+  assert_dir_not_exists "${TEMP_TEST_DIR}/hour.6.2_hello"
+  assert_dir_not_exists "${TEMP_TEST_DIR}/hour.2.2_hello"
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -469,3 +469,15 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_output --partial "${TEMP_TEST_DIR}/hour.6.2 already exists"
   assert_current_timestamp
 }
+
+@test "the user copies a snapshot, appends \"hello\", and rotates snapshots" {
+  mkdir "${TEMP_TEST_DIR}/minute.120.30"
+  cp -r "${TEMP_TEST_DIR}/minute.120.30" "${TEMP_TEST_DIR}/minute.120.30_hello"
+
+  run rback --rotate -- hour 2 2 6 minute 120 30 "${TEMP_TEST_DIR}"
+
+  assert_failure
+  assert_output --partial "conflicting snapshot names"
+  assert_output --partial "${TEMP_TEST_DIR}/minute.120.30"
+  assert_output --partial "${TEMP_TEST_DIR}/minute.120.30_hello"
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -494,3 +494,13 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_output --partial "${TEMP_TEST_DIR}/hour.2.2"
   assert_output --partial "${TEMP_TEST_DIR}/hour.2.2_hello"
 }
+
+@test "the user backs up after appending \"hello\" to limit+interval snapshot" {
+  mkdir "${TEMP_TEST_DIR}/files"
+
+  mkdir "${TEMP_TEST_DIR}/hour.8.2_hello"
+  run rback -- hour 2 2 6 "${TEMP_TEST_DIR}/files/" "${TEMP_TEST_DIR}"
+
+  assert_failure
+  assert_output --partial "${TEMP_TEST_DIR}/hour.8.2_hello already exists"
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -518,3 +518,17 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_dir_not_exists "${TEMP_TEST_DIR}/hour.6.2_hello"
   assert_dir_not_exists "${TEMP_TEST_DIR}/hour.2.2_hello"
 }
+
+@test "the user appends \"hello\" to a snapshot and backs up" {
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.6.2"
+  mkdir "${TEMP_TEST_DIR}/files"
+
+  mv -- "${TEMP_TEST_DIR}/hour.6.2" "${TEMP_TEST_DIR}/hour.6.2_hello"
+  run rback -- hour 2 2 6 "${TEMP_TEST_DIR}/files/" "${TEMP_TEST_DIR}"
+
+  assert_success
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.6.2"
+  assert_dir_exists "${TEMP_TEST_DIR}/hour.2.2"
+  assert_dir_not_exists "${TEMP_TEST_DIR}/hour.6.2_hello"
+  assert_dir_not_exists "${TEMP_TEST_DIR}/hour.2.2_hello"
+}


### PR DESCRIPTION
This closes #9.  This is a new feature that allows the user to append anything to the end of a snapshot folder name (e.g., rename "hour.4.4" to "hour.4.4_hello_world").  The appended information will be lost after backing up or rotating snapshots.  The script produces an error message and exits whenever there is a naming conflict (e.g., both "hour.4.4" and "hour.4.4_hello" cannot both exist when backing up or rotating snapshots).

- `tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
- `tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
- `shellcheck src/rback` passed with ShellCheck version 0.7.0