### PR TITLE
Add ability to append timestamp info to snapshot folder names with the "-a" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 $ src/rback -h
 
 Usage: rback -h
-       rback [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \
+       rback [ -v ] [ -a ] \
+           [ [ --delete-excluded ] --exclude-file <filename> ] \
            -- UNIT START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
-       rback -r [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \
+       rback -r [ -v ] [ -a ] \
+           [ [ --delete-excluded ] --exclude-file <filename> ] \
            -- UNIT1 START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
   OPTIONS
     -h, --help            Display this help message
@@ -16,6 +18,7 @@ Usage: rback -h
     -v, --verbose         Enable logging.  Verbose output with timestamps
     -x, --exclude-file    Flag for exclusion file passed to Rsync
     -d, --delete-excluded Flag for deleting excluded backup files and folders
+    -a, --add-timestamps  Flag to append timestamps to snapshot folder names
   ARGS
     UNIT                  Unit of time (minute, hour, day, week, month, etc.)
     START                 Integer elapsed start time, time for first snapshot

--- a/features/append_timestamp.feature
+++ b/features/append_timestamp.feature
@@ -48,3 +48,9 @@ Scenario: The user rotates snapshots with "-a" without appended timestamps
     And the directory "${TEMP_TEST_DIR}/hour.4.2_YYYYMMDD_HHMMSS" exists
     And the directory "${TEMP_TEST_DIR}/hour.6.2_YYYYMMDD_HHMMSS" exists
     And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds in each case
+
+Scenario: The user looks up the command line option for adding timestamps
+    When the user enters "rback -h"
+    Then "[ -a ]" is shown in the usage information for "rback"
+    And "[ -a ]" is shown in the usage information for "rback -r"
+    And the options "-a, --add-timestamps" appear as well

--- a/features/append_timestamp.feature
+++ b/features/append_timestamp.feature
@@ -36,3 +36,15 @@ Scenario: The user backs up with "-a" and snapshots have timestamps
     And the directory "${TEMP_TEST_DIR}/hour.4.2_YYYYMMDD_HHMMSS" exists
     And the directory "${TEMP_TEST_DIR}/hour.6.2_YYYYMMDD_HHMMSS" exists
     And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds in each case
+
+Scenario: The user rotates snapshots with "-a" without appended timestamps
+    Given the snapshot folder "${TEMP_TEST_DIR}/hour.2.2" exists
+    And the snapshot folder "${TEMP_TEST_DIR}/hour.4.2" exists
+    And the snapshot folder "${TEMP_TEST_DIR}/hour.6.2" exists
+    And the snapshot folder "${TEMP_TEST_DIR}/minute.120.30" exists
+    When the user executes "rback -a -r -- hour 2 2 6 minute 120 30 ${TEMP_TEST_DIR}"
+    Then the command succeeds
+    And the directory "${TEMP_TEST_DIR}/hour.2.2_YYYYMMDD_HHMMSS" exists
+    And the directory "${TEMP_TEST_DIR}/hour.4.2_YYYYMMDD_HHMMSS" exists
+    And the directory "${TEMP_TEST_DIR}/hour.6.2_YYYYMMDD_HHMMSS" exists
+    And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds in each case

--- a/features/append_timestamp.feature
+++ b/features/append_timestamp.feature
@@ -1,0 +1,16 @@
+Feature: Append timestamp info to all snapshot folder names with "-a"
+
+Background:
+    Given the user has an open terminal with a command line prompt
+    And "${TEMP_TEST_DIR}" is a valid path to a directory
+    And the rback script is on the path
+    And Rsync is installed
+
+
+Scenario: The user backs up with "-a" when no snapshots exist
+    Given the snapshot folder "${TEMP_TEST_DIR}/hour.4.4" does not exist
+    But the folder "${TEMP_TEST_DIR}/files" does exist
+    When the user executes "rback -a -- hour 4 4 12 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}"
+    Then the command succeeds
+    And the directory "${TEMP_TEST_DIR}/hour.4.4_YYYYMMDD_HHMMSS" exists
+    And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds

--- a/features/append_timestamp.feature
+++ b/features/append_timestamp.feature
@@ -14,3 +14,13 @@ Scenario: The user backs up with "-a" when no snapshots exist
     Then the command succeeds
     And the directory "${TEMP_TEST_DIR}/hour.4.4_YYYYMMDD_HHMMSS" exists
     And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds
+
+Scenario: The user rotates snapshots with "-a" when no snapshots exist
+    Given the directory "${TEMP_TEST_DIR}/hour.4.4" does not exist
+    And the directory "${TEMP_TEST_DIR}/hour.8.4" does not exist
+    And the directory "${TEMP_TEST_DIR}/hour.12.4" does not exist
+    But the directory "${TEMP_TEST_DIR}/minute.240.30" exists
+    When the user executes "rback -r -a -- hour 4 4 12 minute 240 30 ${TEMP_TEST_DIR}"
+    Then the command succeeds
+    And the directory "${TEMP_TEST_DIR}/hour.4.4_YYYYMMDD_HHMMSS" exists
+    And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds

--- a/features/append_timestamp.feature
+++ b/features/append_timestamp.feature
@@ -24,3 +24,15 @@ Scenario: The user rotates snapshots with "-a" when no snapshots exist
     Then the command succeeds
     And the directory "${TEMP_TEST_DIR}/hour.4.4_YYYYMMDD_HHMMSS" exists
     And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds
+
+Scenario: The user backs up with "-a" and snapshots have timestamps
+    Given the snapshot folder "${TEMP_TEST_DIR}/hour.2.2" with timestamp appended exists
+    And the snapshot folder "${TEMP_TEST_DIR}/hour.4.2" with timestamp appended exists
+    And the snapshot folder "${TEMP_TEST_DIR}/hour.6.2" with timestamp appended exists
+    And the folder "${TEMP_TEST_DIR}/files" exists
+    When the user executes "rback -a -- hour 2 2 6 ${TEMP_TEST_DIR}/files/ ${TEMP_TEST_DIR}"
+    Then the command succeeds
+    And the directory "${TEMP_TEST_DIR}/hour.2.2_YYYYMMDD_HHMMSS" exists
+    And the directory "${TEMP_TEST_DIR}/hour.4.2_YYYYMMDD_HHMMSS" exists
+    And the directory "${TEMP_TEST_DIR}/hour.6.2_YYYYMMDD_HHMMSS" exists
+    And "YYYYMMDD" and "HHMMSS" is the current timestamp info within 5 seconds in each case

--- a/src/rback
+++ b/src/rback
@@ -26,9 +26,11 @@ usage() {
   fi
   local usage_string
   usage_string="Usage: rback -h
-       rback [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \\
+       rback [ -v ] [ -a ] \\
+           [ [ --delete-excluded ] --exclude-file <filename> ] \\
            -- UNIT START INTERVAL LIMIT SRC1 [ SRC2 [ ... ] ] DEST
-       rback -r [ -v ] [ [ --delete-excluded ] --exclude-file <filename> ] \\
+       rback -r [ -v ] [ -a ] \\
+           [ [ --delete-excluded ] --exclude-file <filename> ] \\
            -- UNIT1 START1 INTERVAL1 LIMIT1 UNIT2 START2 INTERVAL2 DEST
   OPTIONS
     -h, --help            Display this help message
@@ -36,6 +38,7 @@ usage() {
     -v, --verbose         Enable logging.  Verbose output with timestamps
     -x, --exclude-file    Flag for exclusion file passed to Rsync
     -d, --delete-excluded Flag for deleting excluded backup files and folders
+    -a, --add-timestamps  Flag to append timestamps to snapshot folder names
   ARGS
     UNIT                  Unit of time (minute, hour, day, week, month, etc.)
     START                 Integer elapsed start time, time for first snapshot
@@ -237,7 +240,7 @@ main() {
       -x|--exclude-file|--exclude-from) exclude_file="$2"; shift ;;
       -d|--delete-excluded) delete_excluded="true" ;;
       -v|--verbose) verbose="true" ;;
-      -a|--add-timestamp) add_timestamp="true" ;;
+      -a|--add-timestamps) add_timestamp="true" ;;
       --) shift; break ;;
       -*) unknown_option="$1" ;;
       *) break ;;

--- a/src/rback
+++ b/src/rback
@@ -58,14 +58,17 @@ usage() {
 # an empty snapshot folder corresponding to <start> <time unit>s will be
 # created.
 #
-# Usage: rotate <backup dir> <time unit> <start> <interval> <limit> [<verbose>]
+# Usage: rotate <backup dir> <time unit> <start> <interval> <limit> <verbose> \
+#                 <timestamp>
 #
 # Inputs: <backup dir> - path to the directory containing all snapshot folders
 #         <time unit> - unit of time ("minute","hour","day",etc.)
 #         <start> - integer elapsed start time, time of the first snapshot
 #         <interval> - integer interval of elapsed time, time between snapshots
 #         <limit> - integer limit of elapsed time, time limit of snapshots
-#         <verbose> - (optional) if "true", then print verbose output
+#         <verbose> - if "true", then print verbose output
+#         <timestamp> - if "true", then append timestamp info to every snapshot
+#                 folder name
 #
 # In the backup directory, a snapshot folder for <limit> + <interval> elapsed
 # time will be created temporarily if it does not already exist; otherwise,
@@ -84,6 +87,8 @@ rotate() {
   limit=$5
   local verbose
   verbose=$6
+  local timestamp
+  timestamp=$7
 
   local temp_folder # temporary snapshot folder name
   temp_folder="$(snapshot_dir_name "${backup_dir}" "${time_unit}" \
@@ -95,10 +100,10 @@ rotate() {
   fi
 
   for (( n = limit; n >= start; n -= interval )); do
-    update "${backup_dir}" "${time_unit}" $n "${interval}"
+    update "${backup_dir}" "${time_unit}" $n "${interval}" "" "${timestamp}"
   done
   update "${backup_dir}" "${time_unit}" "$(( limit + interval ))" \
-        "${interval}" "${start}"
+        "${interval}" "${start}" "${timestamp}"
 }
 
 # Update a snapshot folder to the next interval of, or given, elapsed time
@@ -112,42 +117,48 @@ rotate() {
 #    <time before> - integer elapsed time for the snapshot before update
 #    <interval> - integer interval of elapsed time, for the snapshot before
 #                 update
-#    <time after> - (optional) integer elapsed time, for the snapshot after
-#                 update.  An empty argument implies that the snapshot
+#    <time after> - integer elapsed time, for the snapshot after
+#                 update.  An empty string argument implies that the snapshot
 #                 will have a total elapsed time of <time before> + <interval>
 #                 after update 
+#    <timestamp> - if "true", then append timestamp info to the end of the
+#                 updated snapshot folder name
 #
 #  This function changes the name of the snapshot folder corresponding to the
-#  input arguments, if such a snapshot exits.  Otherwise, in the case of 4 
-#  input arguments, nothing will be done.  In the case of 5 input arguments,
+#  input arguments, if such a snapshot exits.  Otherwise, in the case of
+#  an empty string for the 5th argument, nothing will be done.
+#  In the case of a non-empty 5th input argument,
 #  the function will create an empty snapshot folder corresponding to the
-#  elapsed time after the update.  An error will occur if the
-#  number of arguments to this function is incorrect.
+#  elapsed time after the update.
 update() {
-  local snapshot_prefix
-  snapshot_prefix="$1/$2."
+  local updated_snapshot
+  updated_snapshot="$1/$2."
   local elapsed_time
   elapsed_time=$3
   local interval
   interval=$4
   local snapshot_to_update
   snapshot_to_update="$(snapshot_dir_name "$1" "$2" "$3" "$4")"
+  local timestamp_info
 
-  if (( $# == 4 )); then
+  if [[ "$6" == "true" ]]; then
+    timestamp_info="_$(date +'%Y%m%d_%H%M%S')"
+  else
+    timestamp_info=""
+  fi
+
+  if [[ -z "$5" ]]; then
     if [[ -d "${snapshot_to_update}" ]]; then
-      mv -- "${snapshot_to_update}" \
-          "${snapshot_prefix}$(( elapsed_time + interval )).$(( interval ))"
-    fi
-  elif (( $# == 5 )); then
-    if [[ -d "${snapshot_to_update}" ]]; then
-      mv -- "${snapshot_to_update}" "${snapshot_prefix}$5.$(( interval ))"
-    else
-      mkdir "${snapshot_prefix}$5.$(( interval ))"
+      updated_snapshot+="$(( elapsed_time + interval )).$(( interval ))"
+      mv -- "${snapshot_to_update}" "${updated_snapshot}${timestamp_info}"
     fi
   else
-    local error_prefix
-    error_prefix="${FUNCNAME[0]}: ${LINENO[0]}:"
-    error "${error_prefix} $# arguments were passed, but expected 4 or 5."
+    updated_snapshot+="$5.$(( interval ))"
+    if [[ -d "${snapshot_to_update}" ]]; then
+      mv -- "${snapshot_to_update}" "${updated_snapshot}${timestamp_info}"
+    else
+      mkdir "${updated_snapshot}${timestamp_info}"
+    fi
   fi
 }
 
@@ -216,6 +227,8 @@ main() {
   unknown_option=""
   local error_prefix
   error_prefix=""
+  local add_timestamp
+  add_timestamp="false"
 
   while :; do
     case "$1" in
@@ -224,6 +237,7 @@ main() {
       -x|--exclude-file|--exclude-from) exclude_file="$2"; shift ;;
       -d|--delete-excluded) delete_excluded="true" ;;
       -v|--verbose) verbose="true" ;;
+      -a|--add-timestamp) add_timestamp="true" ;;
       --) shift; break ;;
       -*) unknown_option="$1" ;;
       *) break ;;
@@ -308,7 +322,7 @@ main() {
   fi
 
   rotate "${backup_dir}" "${time_unit}" "${start}" "${interval}" "${limit}" \
-      "${verbose}"
+      "${verbose}" "${add_timestamp}"
   target_dir="$(snapshot_dir_name "${backup_dir}" "${time_unit}" \
       "$(( start ))" "${interval}" "${verbose}")"
 

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -48,7 +48,13 @@ assert_inodes_not_equal() {
 }
 
 assert_current_timestamp() {
-  (( $(date +%s) - $(date -d "${output:0:19}" +%s) < 5 )) # within 5 second
+  local date_string
+  if (( $# == 0 )); then
+    date_string="${output:0:19}"
+  elif (( $# == 1)); then # input string format: "YYYYMMDD_HHMMSS"
+    date_string="${1:0:8} ${1:9:2}:${1:11:2}:${1:13:2}"
+  fi
+  (( $(date +%s) - $(date -d "${date_string}" +%s) < 5 )) # within 5 second
 }
 
 @test "script file exists" {
@@ -531,4 +537,13 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   assert_dir_exists "${TEMP_TEST_DIR}/hour.2.2"
   assert_dir_not_exists "${TEMP_TEST_DIR}/hour.6.2_hello"
   assert_dir_not_exists "${TEMP_TEST_DIR}/hour.2.2_hello"
+}
+
+@test "the user backs up with \"-a\" when no snapshots exist" {
+  mkdir "${TEMP_TEST_DIR}/files"
+
+  run rback -a -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TEST_DIR}"
+  assert_success
+  snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.4.4* | egrep 'hour.4.4_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
 }

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -547,3 +547,13 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.4.4* | egrep 'hour.4.4_[[:digit:]]{8}_[[:digit:]]{6}')"
   assert_current_timestamp "${snapshot_dir: -15}"
 }
+
+@test "the user rotates snapshots with \"-a\" when no snapshots exist" {
+  mkdir "${TEMP_TEST_DIR}/minute.240.30"
+
+  run rback -r -a -- hour 4 4 12 minute 240 30 "${TEMP_TEST_DIR}"
+
+  assert_success
+  snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.4.4* | egrep 'hour.4.4_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -591,3 +591,12 @@ snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.6.2* | egrep 'hour.6.2_[[:digit:]]{8
 snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.6.2* | egrep 'hour.6.2_[[:digit:]]{8}_[[:digit:]]{6}')"
   assert_current_timestamp "${snapshot_dir: -15}"
 }
+
+
+@test "the user looks up the command line option for adding timestamps" {
+  run rback -h
+
+  assert_output --regexp "rback .*\[ -a \]"
+  assert_output --regexp "rback -r .*\[ -a \]"
+  assert_output --partial "-a, --add-timestamps"
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -557,3 +557,23 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
   snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.4.4* | egrep 'hour.4.4_[[:digit:]]{8}_[[:digit:]]{6}')"
   assert_current_timestamp "${snapshot_dir: -15}"
 }
+
+@test "the user backs up with \"-a\" and snapshots have timestamps" {
+  mv -- "${TEMP_TEST_DIR}/hour.2.2" \
+      "${TEMP_TEST_DIR}/hour.2.2_$(date +'%Y%m%d')_$(date +'%H%M%S')"
+  mv -- "${TEMP_TEST_DIR}/hour.4.2" \
+      "${TEMP_TEST_DIR}/hour.4.2_$(date +'%Y%m%d')_$(date +'%H%M%S')"
+  mv -- "${TEMP_TEST_DIR}/hour.6.2" \
+      "${TEMP_TEST_DIR}/hour.6.2_$(date +'%Y%m%d')_$(date +'%H%M%S')"
+  mkdir "${TEMP_TEST_DIR}/files"
+
+  run rback -a -- hour 2 2 6 "${TEMP_TEST_DIR}/files/" "${TEMP_TEST_DIR}"
+
+  assert_success
+  snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.2.2* | egrep 'hour.2.2_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+  snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.4.2* | egrep 'hour.4.2_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.6.2* | egrep 'hour.6.2_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+}

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -577,3 +577,17 @@ run rback --delete-excluded -- hour 4 4 12 "${TEMP_TEST_DIR}/files/" "${TEMP_TES
 snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.6.2* | egrep 'hour.6.2_[[:digit:]]{8}_[[:digit:]]{6}')"
   assert_current_timestamp "${snapshot_dir: -15}"
 }
+
+@test "the user rotates snapshots with \"-a\" without appended timestamps" {
+  mkdir "${TEMP_TEST_DIR}/minute.120.30"
+
+  run rback -a -r -- hour 2 2 6 minute 120 30 "${TEMP_TEST_DIR}"
+
+  assert_success
+  snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.2.2* | egrep 'hour.2.2_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+  snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.4.2* | egrep 'hour.4.2_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.6.2* | egrep 'hour.6.2_[[:digit:]]{8}_[[:digit:]]{6}')"
+  assert_current_timestamp "${snapshot_dir: -15}"
+}


### PR DESCRIPTION
This closes #11.  This is a new feature that allows the user to append timestamp information to the end of snapshot folder names when backing up or rotating.  Only modified snapshot folders, due to rotating snapshots or backing up, will have timestamps appended to their names.

- `tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
- `tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
- `shellcheck src/rback` passed with ShellCheck version 0.7.0