### PR TITLE
Add timestamp to error messages with "-v" for some snapshot folder naming conflicts

### DIFF
--- a/src/rback
+++ b/src/rback
@@ -103,10 +103,11 @@ rotate() {
   fi
 
   for (( n = limit; n >= start; n -= interval )); do
-    update "${backup_dir}" "${time_unit}" $n "${interval}" "" "${timestamp}"
+    update "${backup_dir}" "${time_unit}" $n "${interval}" "" "${timestamp}" \
+        "${verbose}"
   done
   update "${backup_dir}" "${time_unit}" "$(( limit + interval ))" \
-        "${interval}" "${start}" "${timestamp}"
+        "${interval}" "${start}" "${timestamp}" "${verbose}"
 }
 
 # Update a snapshot folder to the next interval of, or given, elapsed time
@@ -126,6 +127,7 @@ rotate() {
 #                 after update 
 #    <timestamp> - if "true", then append timestamp info to the end of the
 #                 updated snapshot folder name
+#    <verbose> - if "true", then print verbose output
 #
 #  This function changes the name of the snapshot folder corresponding to the
 #  input arguments, if such a snapshot exits.  Otherwise, in the case of
@@ -141,7 +143,7 @@ update() {
   local interval
   interval=$4
   local snapshot_to_update
-  snapshot_to_update="$(snapshot_dir_name "$1" "$2" "$3" "$4")"
+  snapshot_to_update="$(snapshot_dir_name "$1" "$2" "$3" "$4" "$7")"
   local timestamp_info
 
   if [[ "$6" == "true" ]]; then
@@ -175,7 +177,7 @@ update() {
 #    <time unit> - unit of time ("minute","hour","day",etc.)
 #    <elapsed time> - integer elapsed time for the snapshot
 #    <interval> - integer interval of elapsed time
-#    <verbose> - (optional) if "true", then print verbose output for errors
+#    <verbose> - if "true", then print verbose output for errors
 #
 # This function prints the unique name of the snapshot folder made after
 # <elapsed time> <time unit>s of time with the snapshot made every <interval>

--- a/tests/test_rback.bats
+++ b/tests/test_rback.bats
@@ -600,3 +600,16 @@ snapshot_dir="$(ls -d ${TEMP_TEST_DIR}/hour.6.2* | egrep 'hour.6.2_[[:digit:]]{8
   assert_output --regexp "rback -r .*\[ -a \]"
   assert_output --partial "-a, --add-timestamps"
 }
+
+@test "the user copies last snapshot, appends \"hello\", and rotates snapshots" {
+  mkdir "${TEMP_TEST_DIR}/minute.120.30"
+  
+  cp -r "${TEMP_TEST_DIR}/hour.6.2" "${TEMP_TEST_DIR}/hour.6.2_hello"
+  run rback --rotate -v -- hour 2 2 6 minute 120 30 "${TEMP_TEST_DIR}"
+
+  assert_failure
+  assert_output --partial "conflicting snapshot names"
+  assert_output --partial "${TEMP_TEST_DIR}/hour.6.2"
+  assert_output --partial "${TEMP_TEST_DIR}/hour.6.2_hello"
+  assert_current_timestamp
+}


### PR DESCRIPTION
This fixes #13.  This fixes the bug where some snapshot directory naming conflict error messages would not print timestamp information with "-v".

- `tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
- `tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
- `shellcheck src/rback` passed with ShellCheck version 0.7.0