### PR TITLE
Remove the word "run" in feature file

### DIFF
--- a/features/error_timestamp.feature
+++ b/features/error_timestamp.feature
@@ -8,14 +8,14 @@ Background:
 
 
 Scenario: The user passes fewer than 6 arguments with "-v"
-    When the user executes "run rback -v -- minute 30 30 480 "${TEMP_TEST_DIR}"
+    When the user executes "rback -v -- minute 30 30 480 "${TEMP_TEST_DIR}"
     Then the command fails
     And a message is printed to standard error
     And the message contains the phrase "at least 6 required"
     And the message contains the current timestamp within a 5 second difference
 
 Scenario: The user passes the wrong number of arguments with "-r" and "-v"
-    When the user executes "run rback -r -v -- minute 10 120 10 hour 2 2"
+    When the user executes "rback -r -v -- minute 10 120 10 hour 2 2"
     Then the command fails
     And a message is printed to standard error
     And the message contains the phrase "expected 8"


### PR DESCRIPTION
This fixes #15.  This is a minor bug fix that removes "run" from a feature file.  The keyword "run" is used in test code but should not appear in scenarios.

- `tests/bats/bin/bats tests` passed locally on Ubuntu 20.04 with Bash 5.0.17(1)-release and Rsync version 3.1.3 protocol version 31
- `tests/bats/bin/bats tests` passed in an "rbacktest" Docker container after building the image with `docker build -t  rbacktest .`
- `shellcheck src/rback` passed with ShellCheck version 0.7.0